### PR TITLE
bump dependency, add depdencabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Install OpenFGA CLI
-      uses: jaxxstorm/action-install-gh-release@v1.10.0
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: openfga/cli
         cache: enable


### PR DESCRIPTION
- Bump `install-a-binary-from-github-releases` to v1.11.0
- Add dependabot for github action dependencies

## Description
This workflow currently still relies on node 16 because of an not up-to-date version of install-a-binary-from-github-releases. This action has migrated to node 20 with version v1.11.0.

See the GitHub announcement here: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

In addition, this pull request adds dependabot to get notified in the future.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
