### PR TITLE
feat!: support multiple test files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: Test Action
 
 on:
   workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
+      - name: default values
+        uses: ./
+      - name: specify folder
+        uses: ./
         with:
-          store-file-path: ./example/model.fga.yaml
+          test_path: ./example
+      - name: single file
+        uses: ./
+        with:
+          test_path: ./example/model.fga.yaml

--- a/README.md
+++ b/README.md
@@ -2,15 +2,38 @@
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fopenfga%2Faction-openfga-test.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fopenfga%2Faction-openfga-test?ref=badge_shield)
 
 
-This action can be used to test your authorization model using a store file.
+This action can be used to test your authorization model using store test files.
 
 ## Parameter
 
-| Parameter  | Description   |
-|----------|--------------|
-| `store-file-path` | The path to your store file relative to the root of your project     | 
+| Parameter            | Description                                                                      | Required | Default      |
+|----------------------|----------------------------------------------------------------------------------|----------|--------------|
+| `test_path`          | The path to your store test file or folder relative to the root of your project. | No       | `.`          |
+| `test_files_pattern` | The pattern to match test files.                                                 | No       | `*.fga.yaml` |
 
-## Example
+> Note: the action will fail if no test is found in the specified test path with the given pattern
+
+
+## Examples
+
+
+### Running tests of `*.fga.yaml` files present in the repository
+
+```yaml
+name: Test Action
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openfga/action-openfga-test@v0.1
+```
+
+### Running tests of `*.fga.yaml` files present in a given folder
 
 ```yaml
 name: Test Action
@@ -25,7 +48,25 @@ jobs:
     steps:
       - uses: openfga/action-openfga-test@v0.1
         with:
-          store-file-path: ./example/model.fga.yaml
+          test_path: example
+```
+
+### Running tests of a single file
+
+```yaml
+name: Test Action
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openfga/action-openfga-test@v0.1
+        with:
+          test_path: example/model.fga.yaml
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,14 @@ branding:
   color: 'green'
 
 inputs:
-  store-file-path:
-    description: The path to the store file
-    required: true
+  test_path:
+    description: 'Path to the test file or folder'
+    required: false
+    default: '.'
+  test_files_pattern:
+    description: 'Pattern to match the test files'
+    required: false
+    default: '*.fga.yaml'
 
 runs:
   using: composite
@@ -19,4 +24,15 @@ runs:
         cache: enable
     - name: Run OpenFGA CLI
       shell: bash
-      run: fga model test --tests ${{ inputs.store-file-path }}
+      run: |
+          while IFS= read -r -d '' test_file
+          do
+            ((test_files_count+=1))
+            echo "Running FGA test file ${test_file}"
+            fga model test --tests "${test_file}"
+          done <   <(find ${{ inputs.test_path }} -name "${{ inputs.test_files_pattern }}" -print0)
+  
+          if [[ ${test_files_count} -eq 0 ]]; then
+            echo "No FGA test file found for path '${{ inputs.test_path }}' and pattern '${{ inputs.test_files_pattern }}'"
+            exit 1
+          fi


### PR DESCRIPTION
Hello there,

Here is a proposal for supporting multiple test files.

## Description
The action would have 2 optional parameters:
* `test_path` to specify a test file or folder (default value `.`)
* `test_files_pattern` to specify the pattern used to match test files (default value `*.fga.yaml`)


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
