### PR TITLE
ci: pin action versions by sha

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,9 @@ jobs:
       OPENFGA_DATASTORE_URI: 'postgres://openfga:1234@127.0.0.1:5432/openfga'
       OPENFGA_LOG_LEVEL: debug
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install OpenFGA server ${{ matrix.test.openfga_tag }}
-        uses: jaxxstorm/action-install-gh-release@v1.13.0
+        uses: jaxxstorm/action-install-gh-release@7f2440a9a41f74262d8f6433da138c799799a969 # v1.13.0
         with:
           repo: openfga/openfga
           tag: ${{ matrix.test.openfga_tag }}
@@ -65,12 +65,12 @@ jobs:
         shell: bash
         run: openfga run &
       - name: Install OpenFGA cli
-        uses: jaxxstorm/action-install-gh-release@v1.13.0
+        uses: jaxxstorm/action-install-gh-release@7f2440a9a41f74262d8f6433da138c799799a969 # v1.13.0
         with:
           repo: openfga/cli
           cache: enable
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2
+        uses: dcarbone/install-jq-action@e397bd87438d72198f81efd21f876461183d383a # v3.0.1
       - name: Create store with model
         id: 'store'
         run: |

--- a/action.yml
+++ b/action.yml
@@ -31,11 +31,11 @@ runs:
   using: composite
   steps:
     - name: Install OpenFGA CLI
-      uses: jaxxstorm/action-install-gh-release@v1.13.0
+      uses: jaxxstorm/action-install-gh-release@7f2440a9a41f74262d8f6433da138c799799a969 # v1.13.0
       with:
         repo: openfga/cli
         cache: enable
-    - uses: chrisdickinson/setup-yq@v1.0.1
+    - uses: chrisdickinson/setup-yq@3d931309f27270ebbafd53f2daee773a82ea1822 # v1.0.0
       with:
         yq-version: v4.25.3
     - name: Run OpenFGA CLI


### PR DESCRIPTION
## Description

We already do this in https://github.com/openfga/action-openfga-deploy but not here, we should pin by sha to improve the security of these actions as a tag is immutable and can be changed,

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
