### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test Action
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/action-openfga-test/security/code-scanning/2](https://github.com/openfga/action-openfga-test/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or to the specific job(s) that do not already have one. The minimal safe default is `contents: read`, which allows the workflow to read repository contents but not write to them. This should be added at the workflow root (applies to all jobs) or at the job level (applies only to that job). Since the CodeQL warning is for the `test_conditions_support` job, and the other job (`test`) also does not have a `permissions` block, the best fix is to add `permissions: contents: read` at the top level of the workflow, just after the `name` field. This ensures all jobs in the workflow have the least privilege by default.

**What to change:**  
- In `.github/workflows/test.yml`, add the following lines after the `name: Test Action` line (line 1):

```yaml
permissions:
  contents: read
```

No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
