### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test Action
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/action-openfga-test/security/code-scanning/1](https://github.com/openfga/action-openfga-test/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The safest and most general approach is to add `permissions: contents: read` at the top level of the workflow, which will apply to all jobs unless overridden. This ensures that the workflow and its jobs only have read access to repository contents, preventing any accidental or malicious write operations. The change should be made near the top of the file, after the `name` and before the `on` block, or at the job level if more granular control is needed. Since there is no evidence that any job in this workflow requires write permissions, `contents: read` is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
